### PR TITLE
[10.x] Configurable storage path via environment variable

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -529,8 +529,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
-        if ($customStoragePath = Env::get('STORAGE_PATH')) {
-            return $this->joinPaths($this->storagePath ?: $customStoragePath, $path);
+        if ($storagePath = Env::get('LARAVEL_STORAGE_PATH')) {
+            return $this->joinPaths($this->storagePath ?: $storagePath, $path);
         }
 
         return $this->joinPaths($this->storagePath ?: $this->basePath('storage'), $path);

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -529,8 +529,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
-        if ($storagePath = Env::get('LARAVEL_STORAGE_PATH')) {
-            return $this->joinPaths($this->storagePath ?: $storagePath, $path);
+        if (isset($_ENV['LARAVEL_STORAGE_PATH'])) {
+            return $this->joinPaths($this->storagePath ?: $_ENV['LARAVEL_STORAGE_PATH'], $path);
         }
 
         return $this->joinPaths($this->storagePath ?: $this->basePath('storage'), $path);

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -529,6 +529,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
+        if ($customStoragePath = Env::get('STORAGE_PATH')) {
+            return $this->joinPaths($this->storagePath ?: $customStoragePath, $path);
+        }
+
         return $this->joinPaths($this->storagePath ?: $this->basePath('storage'), $path);
     }
 


### PR DESCRIPTION
In the current implementation, the storage directory is statically set to `storage`. Given that this directory requires write permissions, it poses challenges in serverless environments and other scenarios where the filesystem might be read-only.

To enhance Laravel's adaptability to diverse hosting environments, this pull request introduces the capability to override the default storage directory using the `STORAGE_PATH` environment variable.