### PR TITLE
[10.x] Add hasAttribute and hasAttributes method to HasAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1793,6 +1793,35 @@ trait HasAttributes
     }
 
     /**
+     * Determine if a model's attribute equals a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function hasAttribute($attribute, $value)
+    {
+        return $this->getAttribute($attribute) === $value;
+    }
+
+    /**
+     * Check if the model has the specified attributes with the given values.
+     *
+     * @param  array  $attributes
+     * @return bool
+     */
+    public function hasAttributes(array $attributes)
+    {
+        foreach ($attributes as $attribute => $value) {
+            if ($this->getAttribute($attribute) !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Set the array of model attributes. No checking is done.
      *
      * @param  array  $attributes


### PR DESCRIPTION
This PR adds a `hasAttributes` and `hasAttribute` method to the Eloquent Model, providing a straightforward way to check if a model’s attributes match specified values.

### Usage Example

```php
$user = new User(['name' => 'John', 'role' => 'admin']);
$user->hasAttributes(['role' => 'admin']); // Returns true
$user->hasAttribute('name', 'John'); // Returns true
```

### Background and Justification

In the development of a package for automatic Laravel code generation (Migrations, Validation, Factories, etc.) I realized that most of Laravel’s code could be generated using simple [$key => $value] arrays, which are then can be translated into Model variables or {{$method}}->({{$params}}) chain via Blade templates.

However, an exception arose in the context of Policies and Authentication-related code, which commonly includes conditional statements like return `$user->id == $resource->user_id`. To maintain a consistent and fluent chain approach, characteristic of Laravel, the introduction of hasAttribute provides a seamless way to handle these conditions.